### PR TITLE
Add xref and dependency checks to elixir workflow

### DIFF
--- a/.github/workflows/elixir-build-check.yaml
+++ b/.github/workflows/elixir-build-check.yaml
@@ -58,3 +58,31 @@ jobs:
             _build/dev/*.plt
             _build/dev/*.plt.hash
       - run: mix do compile --force, dialyzer
+  dependency-audit:
+    name: Dependency Audit
+    needs: [dependencies]
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: rentpath/actions-services-elixir-deps@v1
+        with:
+          elixir-version: ${{ inputs.elixir-version }}
+          erlang-version: ${{ inputs.erlang-version }}
+          mix-env: ${{ inputs.mix-env }}
+      - name: Check for unused dependencies
+        if: always()
+        run: mix deps.unlock --check-unused
+      - name: Check for deprecated packages
+        if: always()
+        run: mix hex.audit
+  xref:
+    name: Xref
+    needs: [dependencies]
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - uses: rentpath/actions-services-elixir-deps@v1
+        with:
+          elixir-version: ${{ inputs.elixir-version }}
+          erlang-version: ${{ inputs.erlang-version }}
+          mix-env: ${{ inputs.mix-env }}
+      - name: Check for circular dependencies
+        run: mix xref graph --label compile-connected --fail-above 0


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/EPIC-765)

Based on https://felt.com/blog/hashrocket-ultimate-elixir-to-the-next-level

Note that this should not be merged until we are moving to Elixir 1.13 or greater as the `mix xref` command isn't supported in Elixir 1.12.

## Code quality

Not yet supported in elixir 1.12
```
mix xref graph --label compile-connected --fail-above 0
```

## Packages

```
mix deps.unlock --check-unused
mix hex.audit
```

## Security (not added)

It's not clear if this is worth the hassle or not.

```
mix sobelow --exit --strict -d
```