### PR TITLE
Add mix format check job to elixir-build-checks workflow

### DIFF
--- a/.github/workflows/elixir-build-check.yaml
+++ b/.github/workflows/elixir-build-check.yaml
@@ -86,3 +86,25 @@ jobs:
           mix-env: ${{ inputs.mix-env }}
       - name: Check for circular dependencies
         run: mix xref graph --label compile-connected --fail-above 0
+  format:
+    name: Validate Elixir source formatting complies with `mix format`
+    needs: [dependencies]
+    runs-on: ${{ inputs.runs-on }}
+    steps:
+      - name: Fetch the full repository so we can perform a Git diff
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fetch dependencies as they may be needed by the formatter
+        uses: rentpath/actions-services-elixir-deps@v1
+        with:
+          elixir-version: ${{ inputs.elixir-version }}
+          erlang-version: ${{ inputs.erlang-version }}
+          mix-env: ${{ inputs.mix-env }}
+          skip-checkout: 'true'
+      - name: Check formatting for Elixir files that have changed
+        run: |
+          default_branch_ref="origin/${{ github.event.repository.default_branch }}"
+          git diff --name-only "$default_branch_ref" | \
+          egrep '(\.ex|\.exs)+$' | \
+          xargs --no-run-if-empty mix format --check-formatted --dry-run


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-4854)

These changes add a new `format` job to the elixir-build-checks workflow
that validates the formatting of changed files matches what `mix format`
expects. We only validate the formatting of changed files because right
now our existing code deviates significantly from what the formatter
expects and we do not want to invest the time in updating the format of
all code at once.

Details on the `--no-run-if-empty` flag: I didn't catch this issue
initially because on Mac OS xargs does not run the provided command by
default when input is empty. On all versions of xargs installed on other
linux OSs the --no-run-if-empty command is required. See
https://stackoverflow.com/a/8296746 for details.

Tested here - https://github.com/rentpath/callrail-service/pull/38

* Commit with invalid formatting: https://github.com/rentpath/callrail-service/pull/38/commits/6215c0d4996c43fa6d8660df1e71b31131897fe4
* Commit with corrected formatting: https://github.com/rentpath/callrail-service/pull/38/commits/6725d514ecfdcd3e799e4d24d3fc2ade8448b7e0