### PR TITLE
Simplify name of mix format check

### DIFF
--- a/.github/workflows/elixir-build-check.yaml
+++ b/.github/workflows/elixir-build-check.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Check for circular dependencies
         run: mix xref graph --label compile-connected --fail-above 0
   format:
-    name: Validate Elixir source formatting complies with `mix format`
+    name: Mix Format
     needs: [dependencies]
     runs-on: ${{ inputs.runs-on }}
     steps:


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-3767)

Upon starting the Elixir upgrade work, I found the new mix formatter check name to be too long, this PR shortens it to make it more readable in the Github UI.

Here is a screenshot of the original title, it's too long to fit in the checks dialog box:

<img width="528" alt="Screen Shot 2022-12-21 at 4 43 01 PM" src="https://user-images.githubusercontent.com/1520926/209007814-666bdf67-f3ce-4e67-a7dc-e3f510bff515.png">
