### PR TITLE
Replace compile-connected xref check with circular dependency check

### DIFF
--- a/.github/workflows/elixir-build-check.yaml
+++ b/.github/workflows/elixir-build-check.yaml
@@ -84,8 +84,10 @@ jobs:
           elixir-version: ${{ inputs.elixir-version }}
           erlang-version: ${{ inputs.erlang-version }}
           mix-env: ${{ inputs.mix-env }}
-      - name: Check for circular dependencies
-        run: mix xref graph --label compile-connected --fail-above 0
+      - name: Check for circular dependencies between modules
+        # Set to 7 for now because of Phoenix. In the future we should consider
+        # bumping this down to 4
+        run: mix xref graph --format cycles --min-cycle-size 7 --fail-above 0
   format:
     name: Mix Format
     needs: [dependencies]


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-3779)

For an example see https://til.hashrocket.com/posts/nxnp4llwfm-elixir-compilation-cycles-with-fail-above