### PR TITLE
Pass GitHub PAT into actions-services-elixir-deps

### DIFF
--- a/.github/workflows/deployment-images.yaml
+++ b/.github/workflows/deployment-images.yaml
@@ -117,6 +117,8 @@ jobs:
           tags: ghcr.io/rentpath/${{ needs.set-deployment-image-name.outputs.name }}:${{ needs.set-version.outputs.version }}
           secrets: |
             "github_token=${{ secrets.GHCR_USER_PAT }}"
+          build-args: |
+            "GHCR_USER_PAT=${{ secrets.GHCR_USER_PAT }}"
       - name: Create GitHub Release
         if: github.repository == format('rentpath/{0}', needs.set-deployment-image-name.outputs.name)
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/elixir-build-check.yaml
+++ b/.github/workflows/elixir-build-check.yaml
@@ -29,6 +29,7 @@ jobs:
           elixir-version: ${{ inputs.elixir-version }}
           erlang-version: ${{ inputs.erlang-version }}
           mix-env: ${{ inputs.mix-env }}
+          github-token: ${{ secrets.GHCR_USER_PAT }}
   credo:
     name: Credo
     needs: [dependencies]
@@ -39,6 +40,7 @@ jobs:
           elixir-version: ${{ inputs.elixir-version }}
           erlang-version: ${{ inputs.erlang-version }}
           mix-env: ${{ inputs.mix-env }}
+          github-token: ${{ secrets.GHCR_USER_PAT }}
       - run: mix do compile --force, credo --strict
   dialyzer:
     name: Dialyzer
@@ -50,6 +52,7 @@ jobs:
           elixir-version: ${{ inputs.elixir-version }}
           erlang-version: ${{ inputs.erlang-version }}
           mix-env: ${{ inputs.mix-env }}
+          github-token: ${{ secrets.GHCR_USER_PAT }}
       - name: Cache PLT files
         uses: actions/cache@v3
         with:
@@ -68,6 +71,7 @@ jobs:
           elixir-version: ${{ inputs.elixir-version }}
           erlang-version: ${{ inputs.erlang-version }}
           mix-env: ${{ inputs.mix-env }}
+          github-token: ${{ secrets.GHCR_USER_PAT }}
       - name: Check for unused dependencies
         if: always()
         run: mix deps.unlock --check-unused


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-4904)
    
The actions-services-elixir-deps now accepts a github-token input that
needs to be set to the GHCR_USER_PAT secret value if we want to be able
to download dependencies from private ("internal") Github repositories.
Passing in the secret is necessary because actions cannot access secrets
directly.
    
The GHCR_USER_PAT is also passed in as a build argument for the Docker
build, because dependencies will need to be downloaded inside the
image build as well.

Sample workflow run with these changes - https://github.com/rentpath/listing_review_service/actions/runs/3850733313