### PR TITLE
Disable docker build summary

### DIFF
--- a/.github/workflows/deployment-images.yaml
+++ b/.github/workflows/deployment-images.yaml
@@ -162,3 +162,5 @@ jobs:
           file: ${{ inputs.deployment-test-image-docker-file-path }}
           push: true
           tags: ghcr.io/rentpath/${{ needs.set-image-names.outputs.test-name }}:${{ needs.set-version.outputs.version }}
+        env:
+          DOCKER_BUILD_SUMMARY: false


### PR DESCRIPTION
[card](https://rentgroup.atlassian.net/browse/SRV-6901)

- the summary didn't seem that useful and we probably don't want to re-upload build artifacts