### PR TITLE
fix: allow secrets to be inherited OR overriden

### DIFF
--- a/.github/workflows/deployment-images.yaml
+++ b/.github/workflows/deployment-images.yaml
@@ -42,6 +42,10 @@ on:
         required: true
       GHCR_USER_PAT:
         required: true
+      ROSSUM_APP_ID:
+        required: true
+      ROSSUM_PRIVATE_KEY:
+        required: true 
 
 jobs:
   set-image-names:


### PR DESCRIPTION
[CARD](https://redfin.atlassian.net/browse/DX-5174)

* In order to specify alternative registries, we need to require _all_ secrets that otherwise would be 'inherited'.
* See example here: https://github.com/rentpath/wiki_gen/pull/199/files